### PR TITLE
chore: consolidate dependency updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.15"
+      version = "~> 3.8"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -71,7 +71,7 @@ locals {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # Short seed + derived ARO identifiers to satisfy name length validation
@@ -217,7 +217,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) (~> 2.15)
+- <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) (~> 3.8)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
@@ -276,7 +276,7 @@ Version:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.15"
+      version = "~> 3.8"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -64,7 +64,7 @@ locals {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # Short seed + derived ARO identifiers to satisfy name length validation

--- a/examples/managed-identities/README.md
+++ b/examples/managed-identities/README.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.15"
+      version = "~> 3.8"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -136,7 +136,7 @@ locals {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # Short seed + derived ARO identifiers to satisfy name length validation
@@ -305,7 +305,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) (~> 2.15)
+- <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) (~> 3.8)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
@@ -381,7 +381,7 @@ Version:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 

--- a/examples/managed-identities/main.tf
+++ b/examples/managed-identities/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.15"
+      version = "~> 3.8"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -129,7 +129,7 @@ locals {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # Short seed + derived ARO identifiers to satisfy name length validation

--- a/examples/private/README.md
+++ b/examples/private/README.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.15"
+      version = "~> 3.8"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -71,7 +71,7 @@ locals {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # Short seed + derived ARO identifiers to satisfy name length validation
@@ -218,7 +218,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) (~> 2.15)
+- <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) (~> 3.8)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
@@ -277,7 +277,7 @@ Version:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.15"
+      version = "~> 3.8"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -64,7 +64,7 @@ locals {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # Short seed + derived ARO identifiers to satisfy name length validation

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -17,6 +17,7 @@ resource "azurerm_private_endpoint" "this_managed_dns_zone_groups" {
     # ARO private endpoint subresource names not finalized in scaffold; update when known.
     subresource_names = ["cluster"]
   }
+
   dynamic "ip_configuration" {
     for_each = each.value.ip_configurations
 
@@ -27,6 +28,7 @@ resource "azurerm_private_endpoint" "this_managed_dns_zone_groups" {
       subresource_name   = "cluster"
     }
   }
+
   dynamic "private_dns_zone_group" {
     for_each = length(each.value.private_dns_zone_resource_ids) > 0 ? ["this"] : []
 
@@ -56,6 +58,7 @@ resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
     private_connection_resource_id = azapi_resource.this.id
     subresource_names              = ["cluster"]
   }
+
   dynamic "ip_configuration" {
     for_each = each.value.ip_configurations
 

--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -1,4 +1,3 @@
-
 data "modtm_module_source" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 
@@ -20,6 +19,7 @@ resource "modtm_telemetry" "telemetry" {
     random_id       = one(random_uuid.telemetry).result
   }, { location = local.main_location })
 }
+
 locals {
   avm_azapi_headers = !var.enable_telemetry ? {} : (local.fork_avm ? {
     fork_avm  = "true"
@@ -49,6 +49,7 @@ locals {
   # tflint-ignore: terraform_unused_declarations
   avm_azapi_header = join(" ", [for k, v in local.avm_azapi_headers : "${k}=${v}"])
 }
+
 locals {
   main_location = var.location
 }
@@ -56,4 +57,3 @@ locals {
 data "azapi_client_config" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 }
-

--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,7 @@ resource "azapi_resource" "this" {
       identity_ids = length(local.managed_identities_defaults.user_assigned_resource_ids) > 0 ? local.managed_identities_defaults.user_assigned_resource_ids : null
     }
   }
+
   dynamic "timeouts" {
     for_each = var.timeouts == null ? [] : [var.timeouts]
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,7 @@
 # variables referenced in main.tf are defined and consumer example works.
 # -----------------------------------------------------------------------------
 
+
 variable "api_server_profile" {
   type = object({
     visibility = string


### PR DESCRIPTION
## Summary

- Consolidates open Dependabot updates from #57, #58, #59, #60, #61, #62, and #64.
- Updates `hashicorp/azuread` to `~> 3.8` in all examples.
- Updates `Azure/naming/azurerm` to `0.4.3` in all examples.
- Updates `actions/checkout` to `v7.0.0` in CodeQL workflow.
- Includes AVM pre-commit generated docs and formatting updates.

Supersedes #57, #58, #59, #60, #61, #62, and #64.

## Validation

- `PORCH_NO_TUI=1 .\avm.ps1 pre-commit`
- `PORCH_NO_TUI=1 .\avm.ps1 pr-check`